### PR TITLE
Proj4js

### DIFF
--- a/contrib.make.yml
+++ b/contrib.make.yml
@@ -467,6 +467,8 @@ projects:
 
   proj4js:
     version: "1.2"
+    patch:
+      - "https://www.drupal.org/files/issues/proj4js-rename_make_file_to-2420707-1.patch"
 
   pseudo_field:
     download:

--- a/libraries.make.yml
+++ b/libraries.make.yml
@@ -102,6 +102,13 @@ libraries:
       url: "git@github.com:amsul/pickadate.js.git"
       branch: "master"
       tag: "3.5.6"
+      
+  proj4js:
+    download:
+      type: "git"
+      url: "git@github.com:ITS-UofIowa/proj4js.git"
+      branch: "master"
+      tag: "1.1.0"
 
   respondjs:
     download:


### PR DESCRIPTION
Update proj4js dependency to self-hosted version on github while host is down.