### PR TITLE
Run site install during Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+services:
+  - memcached
+
 matrix:
   fast_finish: true
 
@@ -19,6 +22,7 @@ before_install:
   - phpenv config-rm xdebug.ini
   - composer self-update
   - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 script:
   - phpcs --standard=Drupal,DrupalPractice . --ignore='libraries,modules,themes'
   - drush make --yes --force-gitinfofile --concurrency=6 --contrib-destination=profiles/sitenow profiles/sitenow/build-sitenow.make.yml .
-  - drush --yes site-install sitenow --db-url=mysql://root@localhost/drupal --site-name=sitenow
+  - drush --yes site-install sitenow --db-url=mysql://root@localhost/drupal --site-name=TravisCI
 
 before_deploy:
   - echo -e "\n; Automatically added by Travis packaging script\nversion = $TRAVIS_TAG" >> profiles/sitenow/sitenow.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - $HOME/.composer/cache
 
 services:
+  - mysql
   - memcached
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 script:
   - phpcs --standard=Drupal,DrupalPractice . --ignore='libraries,modules,themes'
   - drush make --yes --force-gitinfofile --concurrency=6 --contrib-destination=profiles/sitenow profiles/sitenow/build-sitenow.make.yml .
+  - drush --yes site-install sitenow --db-url=mysql://root@localhost/drupal --site-name=sitenow
 
 before_deploy:
   - echo -e "\n; Automatically added by Travis packaging script\nversion = $TRAVIS_TAG" >> profiles/sitenow/sitenow.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 
 services:
   - mysql
-  - memcached
 
 matrix:
   fast_finish: true
@@ -23,7 +22,6 @@ before_install:
   - phpenv config-rm xdebug.ini
   - composer self-update
   - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/sitenow.info
+++ b/sitenow.info
@@ -16,7 +16,6 @@ dependencies[] = rdf
 dependencies[] = syslog
 
 ; Contrib
-dependencies[] = acquia_purge
 dependencies[] = ctools
 dependencies[] = email
 dependencies[] = escape_admin

--- a/sitenow.info
+++ b/sitenow.info
@@ -25,7 +25,6 @@ dependencies[] = globalredirect
 dependencies[] = libraries
 dependencies[] = link
 dependencies[] = logintoboggan
-dependencies[] = memcache
 dependencies[] = metatag
 dependencies[] = metatag_panels
 dependencies[] = metatag_views

--- a/sitenow.install
+++ b/sitenow.install
@@ -16,7 +16,7 @@ function sitenow_install() {
 
   // Only enable if running on Acquia Cloud to avoid site install errors.
   if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
-    module_enable('acquia_purge');
+    module_enable(array('acquia_purge'));
   }
 
   sitenow_add_content_types();

--- a/sitenow.install
+++ b/sitenow.install
@@ -9,6 +9,10 @@ function sitenow_install() {
 
   module_enable(array('sitenow_media', 'sitenow_wysiwyg', 'toolbar'));
 
+  // Only enable if the extension is loaded to avoid site install error.
+  if (extension_loaded('memcache') || extension_loaded('memcached')) {
+    module_enable(array('memcache'));
+  }
   sitenow_add_content_types();
   sitenow_add_default_blocks();
   sitenow_enable_theme_settings();

--- a/sitenow.install
+++ b/sitenow.install
@@ -13,6 +13,12 @@ function sitenow_install() {
   if (extension_loaded('memcache') || extension_loaded('memcached')) {
     module_enable(array('memcache'));
   }
+
+  // Only enable if running on Acquia Cloud to avoid site install errors.
+  if (isset($_ENV['AH_SITE_ENVIRONMENT'])) {
+    module_enable('acquia_purge');
+  }
+
   sitenow_add_content_types();
   sitenow_add_default_blocks();
   sitenow_enable_theme_settings();


### PR DESCRIPTION
Changes to the profile sometimes lead to regressions which cause errors during site installation (ex. #64). This PR will run `drush site-install sitenow` as a quick test for that. This requires some modules be enabled depending on the environment - memcache and acquia_purge. They have been moved from dependencies to being enabled in the install file. Profile dependencies do not prevent modules from being disabled/uninstalled.

This change means site provisions should not be run locally. We'll need to update documentation for that.

Resolves #71 
Resolves #47 