### PR TITLE
Change superfish library patch URLs

### DIFF
--- a/sitenow.make.yml
+++ b/sitenow.make.yml
@@ -949,7 +949,7 @@ libraries:
       url: "git@github.com:mehrpadin/Superfish-for-Drupal.git"
       revision: "85e468d71a4882677d0e3596446a91620f9bdcec"
     patch:
-      - "https://raw.github.com/ITS-UofIowa/SiteNow-Custom-Libraries/master/superfish/global_modernizr_and_mq_detection_check.patch"
+      - "https://patch-diff.githubusercontent.com/raw/mehrpadin/Superfish-for-Drupal/pull/6.patch"
       - "https://raw.github.com/ITS-UofIowa/SiteNow-Custom-Libraries/master/superfish/sfautomaticwidth-calc-less-than-100.patch"
 
   underscore:

--- a/sitenow.make.yml
+++ b/sitenow.make.yml
@@ -950,7 +950,7 @@ libraries:
       revision: "85e468d71a4882677d0e3596446a91620f9bdcec"
     patch:
       - "https://patch-diff.githubusercontent.com/raw/mehrpadin/Superfish-for-Drupal/pull/6.patch"
-      - "https://raw.github.com/ITS-UofIowa/SiteNow-Custom-Libraries/master/superfish/sfautomaticwidth-calc-less-than-100.patch"
+      - "https://patch-diff.githubusercontent.com/raw/mehrpadin/Superfish-for-Drupal/pull/18.patch"
 
   underscore:
     download:


### PR DESCRIPTION
The SiteNow-Custom-Libraries repo was deprecated.