### PR TITLE
add usage count for new redirects

### DIFF
--- a/sitenow.profile
+++ b/sitenow.profile
@@ -98,7 +98,7 @@ function sitenow_theme_registry_alter(&$theme_registry) {
 }
 
 /**
- * Implements hook_redirect_save().
+ * Implements hook_redirect_presave().
  */
 function sitenow_redirect_presave($redirect) {
   // Make new redirects have a count of one to avoid them being deleted.

--- a/sitenow.profile
+++ b/sitenow.profile
@@ -96,3 +96,16 @@ function sitenow_theme_registry_alter(&$theme_registry) {
   $theme_registry['webform_edit_file_extensions']['function'] = 'theme_sitenow_edit_file_extensions';
   $theme_registry['webform_edit_file_extensions']['includes'] = array($profile_path . '/includes/' . $file_name);
 }
+
+/**
+ * Implements hook_redirect_save().
+ */
+function sitenow_redirect_presave($redirect) {
+  // Make new redirects have a count of one to avoid them being deleted.
+  // This avoids applying a patch to the redirect module.
+  // Explanation of bug: https://www.drupal.org/node/1396446
+  if ($redirect->is_new == TRUE) {
+    $redirect->count = 1;
+    $redirect->access = REQUEST_TIME;
+  }
+}


### PR DESCRIPTION
This PR addresses #124 by adding the snippet suggested by @brandonneil to avoid new,  un-used redirects from being deleted when cron runs.