### PR TITLE
Patch menu_block to fix undefined index errors

### DIFF
--- a/sitenow.make.yml
+++ b/sitenow.make.yml
@@ -394,6 +394,8 @@ projects:
 
   menu_block:
     version: "2.7"
+    patch:
+      - "https://www.drupal.org/files/issues/menu_block-undefined_index-2642556-7.patch"
 
   menu_link_weight:
     version: "1.4"


### PR DESCRIPTION
Menu Block sometimes causes the error `Undefined index: parent_mlid in menu_tree_block_data()`. This PR applies the patch from https://www.drupal.org/project/menu_block/issues/2642556, which has fixed the issue for me.