### PR TITLE
Enable new custom modules on install

### DIFF
--- a/sitenow.install
+++ b/sitenow.install
@@ -16,7 +16,7 @@ function sitenow_install() {
     'sitenow_media',
     'sitenow_wysiwyg',
     'sitenow_wysiwyg_bonus_pack',
-    'toolbar'
+    'toolbar',
   ));
 
   // Only enable if the extension is loaded to avoid site install error.

--- a/sitenow.install
+++ b/sitenow.install
@@ -12,7 +12,13 @@
  */
 function sitenow_install() {
 
-  module_enable(array('sitenow_footer', 'sitenow_media', 'sitenow_wysiwyg', 'sitenow_wysiwyg_bonus_pack', 'toolbar'));
+  module_enable(array(
+    'sitenow_footer',
+    'sitenow_media',
+    'sitenow_wysiwyg',
+    'sitenow_wysiwyg_bonus_pack',
+    'toolbar'
+  ));
 
   // Only enable if the extension is loaded to avoid site install error.
   if (extension_loaded('memcache') || extension_loaded('memcached')) {

--- a/sitenow.install
+++ b/sitenow.install
@@ -11,7 +11,6 @@
  * Perform actions to set up the site for this profile.
  */
 function sitenow_install() {
-
   module_enable(array(
     'sitenow_footer',
     'sitenow_media',

--- a/sitenow.install
+++ b/sitenow.install
@@ -12,7 +12,7 @@
  */
 function sitenow_install() {
 
-  module_enable(array('sitenow_media', 'sitenow_wysiwyg', 'toolbar'));
+  module_enable(array('sitenow_footer', 'sitenow_media', 'sitenow_wysiwyg', 'sitenow_wysiwyg_bonus_pack', 'toolbar'));
 
   // Only enable if the extension is loaded to avoid site install error.
   if (extension_loaded('memcache') || extension_loaded('memcached')) {


### PR DESCRIPTION
For new sites only, enable sitenow_footer and sitenow_wysiwyg_bonus_pack during site install.