### PR TITLE
Set/update default timezone.

### DIFF
--- a/sitenow.install
+++ b/sitenow.install
@@ -555,3 +555,10 @@ function sitenow_update_7305() {
     theme_disable(array('seven'));
   }
 }
+
+/**
+ * Set default timezone to America/Chicago.
+ */
+function sitenow_update_7306() {
+  variable_set('date_default_timezone', 'America/Chicago');
+}

--- a/sitenow.profile
+++ b/sitenow.profile
@@ -14,6 +14,7 @@ function sitenow_form_install_configure_form_alter(&$form, $form_state) {
   // Pre-populate the site name with the server name.
   $form['site_information']['site_name']['#default_value'] = $_SERVER['SERVER_NAME'];
   $form['server_settings']['site_default_country']['#default_value'] = 'US';
+  $form['server_settings']['date_default_timezone']['#default_value'] = 'America/Chicago';
   $form['update_notifications']['update_status_module']['#default_value'] = array(1);
 }
 


### PR DESCRIPTION
The form alter should set it correctly for sites install via Drush. Resolves #219 